### PR TITLE
server: fix users endpoint and add bypass auth option for dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@
   - [Development environment](#development-environment-1)
     - [Start developing](#start-developing)
     - [Access local endpoints](#access-local-endpoints)
+    - [Bypass Firebase Auth for dev and test environment](#bypass-firebase-auth-for-dev-and-test-environment)
     - [Lint and run tests](#lint-and-run-tests)
 - [API reference](#api-reference)
   - [Authenticated routes](#authenticated-routes)
+  - [Users](#users)
+    - [Register and create a user](#register-and-create-a-user)
   - [Questions](#questions)
     - [Create a question](#create-a-question)
     - [Get all questions](#get-all-questions)
@@ -115,6 +118,22 @@ If there are any errors while connecting to your local MongoDB server, ensure th
 2. Using Postman (or `curl`), make a `GET` call to `http://localhost:8000/api/questions` to verify that the endpoint is working
 3. Refer to the [API reference](#api-reference) for the other endpoints
 
+#### Bypass Firebase Auth for dev and test environment
+
+When running tests and developing locally, you may want to bypass Firebase Auth for your convenience:
+
+```sh
+# change to server/ directory first
+cd server/
+# start a local server with hot reload at port 8000 and bypass firebase auth
+yarn dev:bypass-auth
+```
+
+When developing with this command, the [authentication verifier](https://github.com/CS3219-SE-Principles-and-Patterns/cs3219-ay2021-s1-project-2020-s1-g15/blob/master/server/src/middlewares/authRouteHandler.ts) will:
+
+- Ignore and skip the verification of the token in the `Authorization` request headers (if any)
+- Always store in `res.locals.uid` the `uid` of `devtestuser@answerleh.com` (exact uid: `5f84521e8facd089df29b7a9`), for use by the route being called
+
 #### Lint and run tests
 
 [ESLint](https://eslint.org/) with the [Prettier plugin](https://prettier.io/) is used to lint the source code, while [Jest](https://jestjs.io/) is used as the testing framework. To lint and run all tests:
@@ -149,6 +168,44 @@ Authorization: Bearer <FIREBASE_TOKEN>
 
 - Replace `<FIREBASE_TOKEN>` with the actual token after authenticating with Firebase Auth
 - Make sure that the keyword `Bearer` and a single whitespace is prepended to the token before sending it to the server
+
+### Users
+
+#### Register and create a user
+
+- Method: `POST`
+- URL: `/api/users`
+- Auth required: NO
+- Body data (example):
+  ```js
+  {
+    "email": "yo@answerleh.com", // string; required!
+    "password": "123456", // string; required!
+  }
+  ```
+
+**Success response**:
+
+- Condition: if all required fields are present and valid
+- Code: `201 CREATED`
+- Content (example):
+  ```js
+  {
+    "_id": "5f84521e8facd089df29b7a9",
+    "createdAt": "2020-10-12T12:54:55.874Z",
+    "updatedAt": "2020-10-12T12:54:55.874Z",
+    "email": "devtestuser@answerleh.com",
+    "username": "devtestuser@answerleh.com",
+    "questionIds": [],
+    "answerIds": []
+  }
+  ```
+
+**Error response**:
+
+- Condition: if any required fields are missing or invalid
+- Status: `400 BAD REQUEST`
+- Content: description of error
 
 ### Questions
 

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ cd server/
 yarn dev:bypass-auth
 ```
 
-When developing with this command, the [authentication verifier](https://github.com/CS3219-SE-Principles-and-Patterns/cs3219-ay2021-s1-project-2020-s1-g15/blob/master/server/src/middlewares/authRouteHandler.ts) will:
+When developing with this command, the [middleware responsible for authentication](https://github.com/CS3219-SE-Principles-and-Patterns/cs3219-ay2021-s1-project-2020-s1-g15/blob/master/server/src/middlewares/authRouteHandler.ts) will:
 
 - Ignore and skip the verification of the token in the `Authorization` request headers (if any)
-- Always store in `res.locals.uid` the `uid` of `devtestuser@answerleh.com` (exact uid: `5f84521e8facd089df29b7a9`), for use by the route being called
+- Always store in `res.locals.uid` the `uid` of `devtestuser@answerleh.com` (`5f84521e8facd089df29b7a9`), for use by the next route
 
 #### Lint and run tests
 

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,8 @@
     "test": "cross-env NODE_ENV=test jest --ci --coverage",
     "ci": "yarn lint && yarn test",
     "start": "tsc -p tsconfig.build.json && cross-env NODE_ENV=prod node dist/index.js",
-    "dev": "tsc-watch -p tsconfig.build.json --onSuccess \"cross-env NODE_ENV=dev node dist/index.js\""
+    "dev": "cross-env NODE_ENV=dev tsc-watch -p tsconfig.build.json --onSuccess \"node dist/index.js\"",
+    "dev:bypass-auth": "cross-env BYPASS_AUTH=true yarn dev"
   },
   "dependencies": {
     "@types/cors": "^2.8.7",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,9 +7,14 @@ import { initAuth } from "./services/authentication";
 
 const port: string = process.env.PORT || "8000";
 
-initAuth();
-initDb().then(() => {
+// IIFE to use async await syntax
+(async () => {
+  // init Firebase Auth:
+  await initAuth();
+  // init MongoDB:
+  await initDb();
+  // init Express:
   app.listen(port, () => {
     console.log(`Express: started listening at port ${port}`);
   });
-});
+})();

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -6,7 +6,7 @@ import { createUser } from "../controllers/users";
 
 const router: Router = Router();
 
-router.post("/register", async (req: Request, res: Response) => {
+router.post("/", async (req: Request, res: Response) => {
   const data: UserRequestBody = {
     email: req.body.email,
     password: req.body.password,
@@ -14,7 +14,7 @@ router.post("/register", async (req: Request, res: Response) => {
 
   const createdUser: User = await createUser(data);
 
-  return res.status(HttpStatusCode.OK).json(createdUser);
+  return res.status(HttpStatusCode.CREATED).json(createdUser);
 });
 
 export default router;


### PR DESCRIPTION
- Developers can bypass Firebase Auth and authenticate as a hardcoded test user by using `yarn dev:bypass-auth`
- Change registering endpoint of users from `POST /api/users/register` to `POST /api/users`
- Refer to changes in `REAMDE.md`